### PR TITLE
Add placeholders for DB credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+SUPABASE_JWT_SECRET=your-supabase-jwt-secret # chave secreta JWT usada pelo Supabase
 
 # -----------------------------------------------------------------
 # NEXTAUTH CONFIGURATION  
@@ -37,6 +38,12 @@ GITHUB_CLIENT_SECRET=your-github-client-secret
 # -----------------------------------------------------------------
 # URL do banco (Supabase PostgreSQL ou outro)
 DATABASE_URL=postgresql://user:password@host:port/database
+POSTGRES_HOST=localhost            # host do banco PostgreSQL
+POSTGRES_PORT=5432                 # porta do banco PostgreSQL
+POSTGRES_DATABASE=postgres         # nome do banco de dados
+POSTGRES_USER=postgres             # usuário do banco
+POSTGRES_PASSWORD=password         # senha do banco
+SUPABASE_NEON_NEON_DATABASE_URL=postgresql://user:password@host:port/database # string de conexão alternativa
 
 # -----------------------------------------------------------------
 # API CONFIGURATION


### PR DESCRIPTION
## Summary
- extend `.env.example` with PostgreSQL variables used in `lib/db.ts`

## Testing
- `pytest tests/`
- `pytest tests/test_zapi.py -v` *(fails: file not found)*
- `pytest tests/test_auth.py -v` *(fails: file not found)*