### PR TITLE
Fix Next.js external packages option

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -66,9 +66,7 @@ const nextConfig = {
   },
 
   // Configuração para external packages (Supabase)
-  experimental: {
-    serverComponentsExternalPackages: ['@supabase/supabase-js'],
-  },
+  serverExternalPackages: ['@supabase/supabase-js'],
 
   // ❌ REMOVIDO: transpilePackages com @clerk/nextjs (não está sendo usado)
   


### PR DESCRIPTION
## Summary
- update Next.js config to use `serverExternalPackages`

## Testing
- `pytest tests/`
- `pytest tests/test_zapi.py -v` *(fails: file not found)*
- `pytest tests/test_auth.py -v` *(fails: file not found)*
- `npm run build` *(fails to connect to 172.25.0.3:8080)*